### PR TITLE
Fixing hardcoded unit number in app properties

### DIFF
--- a/src/main/java/org/randywebb/wlts/ldstools/rest/MinistryHelpers.java
+++ b/src/main/java/org/randywebb/wlts/ldstools/rest/MinistryHelpers.java
@@ -17,13 +17,14 @@ public final class MinistryHelpers {
     /** Get the list of ministering brothers and sisters lists.
         Get the contents of the app property ministering-members-endpoint.
         @param client The LDS client to use
+        @param unitId The unit to get the auxiliaries from. This may just be client.getUnitNumber().
         @param htIds List of htAuxiliaries from the endpoint.
         @param vtIds List of vtAuxiliaries from the endpoint.
         @throws IOException on io error
         @throws ParseException on JSON error
     */
-    public static void getAuxiliaries(LdsToolsClient client, List<String> htIds, List<String> vtIds) throws IOException, ParseException {
-        JSONObject members = client.getAppPropertyEndpointInfo("ministering-members-endpoint");
+    public static void getAuxiliaries(LdsToolsClient client, String unitId, List<String> htIds, List<String> vtIds) throws IOException, ParseException {
+        JSONObject members = client.getAppPropertyEndpointInfo("ministering-members-endpoint", unitId);
         JSONArray families = (JSONArray) members.get("families");
 
         for (Object familyObject : families) {

--- a/src/main/java/org/randywebb/wlts/reports/DetailedMinisteredCSV.java
+++ b/src/main/java/org/randywebb/wlts/reports/DetailedMinisteredCSV.java
@@ -43,22 +43,23 @@ public final class DetailedMinisteredCSV {
         @throws ParseException When the JSON is not as we expected
     */
     public static void generateMiniseteredReport(LdsToolsClient client, String filePath, JSONObject relocations) throws IOException, ParseException {
-        JSONObject ward = client.getEndpointInfo("unit-members-and-callings-v2", client.getUnitNumber());
+        String unitNumber = client.getUnitNumber();
+        JSONObject ward = client.getEndpointInfo("unit-members-and-callings-v2", unitNumber);
         List<Household> householdList = Household.fromArray((JSONArray) ward.get("households"));
         List<String> priesthood = new ArrayList<String>();
         List<String> reliefsociety = new ArrayList<String>();
         List<DetailedMinistered> ministered = new ArrayList<DetailedMinistered>();
 
-        MinistryHelpers.getAuxiliaries(client, priesthood, reliefsociety);
+        MinistryHelpers.getAuxiliaries(client, unitNumber, priesthood, reliefsociety);
 
         for (String auxiliaryId : priesthood) {
-            List<District> districts = District.fromArray(client.getAppPropertyEndpointList("ministering-companionships-endpoint", auxiliaryId));
+            List<District> districts = District.fromArray(client.getAppPropertyEndpointList("ministering-companionships-endpoint", unitNumber, auxiliaryId));
 
             ministered.addAll(DetailedMinistered.fromDistricts(districts, householdList, relocations));
         }
 
         for (String auxiliaryId : reliefsociety) {
-            List<District> districts = District.fromArray(client.getAppPropertyEndpointList("ministering-companionships-endpoint", auxiliaryId));
+            List<District> districts = District.fromArray(client.getAppPropertyEndpointList("ministering-companionships-endpoint", unitNumber, auxiliaryId));
 
             ministered.addAll(DetailedMinistered.fromDistricts(districts, householdList, relocations));
         }

--- a/src/main/java/org/randywebb/wlts/reports/MinisteringKML.java
+++ b/src/main/java/org/randywebb/wlts/reports/MinisteringKML.java
@@ -86,7 +86,7 @@ public final class MinisteringKML {
                     String ministryPrefix,
                     String ministerName, String ministeredName,
                     Map<String, Household> map, KMLWriter.List container) throws IOException, ParseException {
-        JSONArray districtsJSON = client.getAppPropertyEndpointList("ministering-companionships-endpoint", auxiliaryId);
+        JSONArray districtsJSON = client.getAppPropertyEndpointList("ministering-companionships-endpoint", client.getUnitNumber(), auxiliaryId);
         List<District> districts = District.fromArray(districtsJSON);
         KMLWriter.Folder folder = new KMLWriter.Folder()
                                     .append(new KMLWriter.Name(auxiliaryName))
@@ -286,7 +286,8 @@ public final class MinisteringKML {
         final int thickLine = 8;
         final int thinLine = 2;
         KMLWriter.Document document = new KMLWriter.Document();
-        JSONObject ward = client.getEndpointInfo("unit-members-and-callings-v2", client.getUnitNumber());
+        String unitNumber = client.getUnitNumber();
+        JSONObject ward = client.getEndpointInfo("unit-members-and-callings-v2", unitNumber);
         JSONArray households = (JSONArray) ward.get("households");
         List<Household> householdList = Household.fromArray(households);
         Map<String, Household> idToHousehold = client.leaderReportsAvailable() ? Household.mapIndividualIdsToHousehold(householdList) : null;
@@ -319,7 +320,7 @@ public final class MinisteringKML {
             List<String> priesthood = new ArrayList<String>();
             List<String> reliefsociety = new ArrayList<String>();
 
-            MinistryHelpers.getAuxiliaries(client, priesthood, reliefsociety);
+            MinistryHelpers.getAuxiliaries(client, unitNumber, priesthood, reliefsociety);
 
             for (String aux : priesthood) {
                 mapCompanionships(client, relocations, routes, aux, "Priesthood",

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -9,10 +9,10 @@ mls-report-endpoint=https://www.lds.org/mls/mbr/services/report/member-list?lang
 unit-members-endpoint=unit-members-and-callings-v2
 
 # Endpoint for Ministering information
-ministering-members-endpoint=https://www.lds.org/htvt/services/v1/2072416/members
+ministering-members-endpoint=https://www.lds.org/htvt/services/v1/%s/members
 
 # Endpoint for Ministering companionships
-ministering-companionships-endpoint=https://www.lds.org/htvt/services/v1/2072416/districts/%s
+ministering-companionships-endpoint=https://www.lds.org/htvt/services/v1/%s/districts/%s
 
 # These are approximate values (specifically for Pflugerville, TX) to get approximate miles
 # We don't need to be too accurate, just get a general sense of distance


### PR DESCRIPTION
Adding a %s in the app properties URLs where there was a hardcoded unit id. Passing unit ID into the locations that use those URLs.