### PR TITLE
Fixing Style tag in .kml files

### DIFF
--- a/src/main/java/org/randywebb/wlts/util/KMLWriter.java
+++ b/src/main/java/org/randywebb/wlts/util/KMLWriter.java
@@ -373,7 +373,7 @@ public final class KMLWriter {
             @throws IOException on io error
         */
         public void write(String prefix, FileWriter output) throws IOException {
-            output.append(prefix + "<" + tag + null == attributes ? "" : (" " + attributes) + ">\n");
+            output.append(prefix + "<" + tag + (null == attributes ? "" : (" " + attributes)) + ">\n");
 
             for (Item item : this) {
                 item.write(prefix + "\t", output);


### PR DESCRIPTION
In my enthusiasm to remove excess parenthesis, I removed some needed parenthesis. Adding them back in.