### PR TITLE
Bulk cleanup of imports

### DIFF
--- a/src/main/java/org/randywebb/wlts/Main.java
+++ b/src/main/java/org/randywebb/wlts/Main.java
@@ -12,17 +12,14 @@ import java.util.Map;
 import java.util.Scanner;
 
 import org.apache.http.auth.AuthenticationException;
-
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.randywebb.wlts.ldstools.rest.LdsToolsClient;
 import org.randywebb.wlts.reports.DetailedMemberListCSV;
 import org.randywebb.wlts.reports.DetailedMinisteredCSV;
 import org.randywebb.wlts.reports.MinisteringKML;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/randywebb/wlts/beans/AbstractBean.java
+++ b/src/main/java/org/randywebb/wlts/beans/AbstractBean.java
@@ -13,11 +13,9 @@ import java.util.Map;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-
-import org.supercsv.cellprocessor.ift.CellProcessor;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.supercsv.cellprocessor.ift.CellProcessor;
 
 /** Abstract class for generic objects.
     Each object is actually a map of string to string.

--- a/src/main/java/org/randywebb/wlts/beans/DetailedMinistered.java
+++ b/src/main/java/org/randywebb/wlts/beans/DetailedMinistered.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.json.simple.JSONObject;
-
 import org.supercsv.cellprocessor.ift.CellProcessor;
 
 //import org.slf4j.Logger;

--- a/src/main/java/org/randywebb/wlts/beans/Household.java
+++ b/src/main/java/org/randywebb/wlts/beans/Household.java
@@ -6,10 +6,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.randywebb.wlts.util.AppConfig;
-
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.randywebb.wlts.util.AppConfig;
 
 //import org.slf4j.Logger;
 //import org.slf4j.LoggerFactory;

--- a/src/main/java/org/randywebb/wlts/ldstools/rest/ApiCatalog.java
+++ b/src/main/java/org/randywebb/wlts/ldstools/rest/ApiCatalog.java
@@ -11,13 +11,10 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
-
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.randywebb.wlts.util.AppConfig;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/randywebb/wlts/reports/DetailedMemberListCSV.java
+++ b/src/main/java/org/randywebb/wlts/reports/DetailedMemberListCSV.java
@@ -6,12 +6,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.randywebb.wlts.beans.DetailedMember;
 import org.randywebb.wlts.ldstools.rest.LdsToolsClient;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.supercsv.cellprocessor.ConvertNullTo;
 import org.supercsv.cellprocessor.FmtBool;
 import org.supercsv.cellprocessor.FmtDate;
@@ -19,10 +20,6 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.io.CsvMapWriter;
 import org.supercsv.io.ICsvMapWriter;
 import org.supercsv.prefs.CsvPreference;
-
-import org.json.simple.JSONArray;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 
 /** Utility methods to export the detailed member list as CSV. */
 public final class DetailedMemberListCSV {

--- a/src/main/java/org/randywebb/wlts/reports/DetailedMinisteredCSV.java
+++ b/src/main/java/org/randywebb/wlts/reports/DetailedMinisteredCSV.java
@@ -1,29 +1,26 @@
 package org.randywebb.wlts.reports;
 
 import java.io.FileWriter;
-import java.io.Writer;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.ParseException;
 import org.randywebb.wlts.beans.DetailedMinistered;
 import org.randywebb.wlts.beans.District;
 import org.randywebb.wlts.beans.Household;
 import org.randywebb.wlts.ldstools.rest.LdsToolsClient;
 import org.randywebb.wlts.ldstools.rest.MinistryHelpers;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.supercsv.cellprocessor.ConvertNullTo;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.io.CsvMapWriter;
 import org.supercsv.io.ICsvMapWriter;
 import org.supercsv.prefs.CsvPreference;
-
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.ParseException;
 
 /** Utility methods to export detailed ministered families in CSV. */
 public final class DetailedMinisteredCSV {

--- a/src/main/java/org/randywebb/wlts/reports/MinisteringKML.java
+++ b/src/main/java/org/randywebb/wlts/reports/MinisteringKML.java
@@ -6,6 +6,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.ParseException;
 import org.randywebb.wlts.beans.Assignment;
 import org.randywebb.wlts.beans.Companionship;
 import org.randywebb.wlts.beans.District;
@@ -15,10 +18,6 @@ import org.randywebb.wlts.beans.Visit;
 import org.randywebb.wlts.ldstools.rest.LdsToolsClient;
 import org.randywebb.wlts.ldstools.rest.MinistryHelpers;
 import org.randywebb.wlts.util.KMLWriter;
-
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.ParseException;
 
 //import org.slf4j.Logger;
 //import org.slf4j.LoggerFactory;

--- a/src/main/java/org/randywebb/wlts/util/KMLWriter.java
+++ b/src/main/java/org/randywebb/wlts/util/KMLWriter.java
@@ -3,7 +3,6 @@ package org.randywebb.wlts.util;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 //import org.slf4j.Logger;
 //import org.slf4j.LoggerFactory;

--- a/src/test/java/org/randywebb/wlts/beans/TestAbstractBean.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestAbstractBean.java
@@ -1,22 +1,15 @@
 package org.randywebb.wlts.beans;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.List;
-import java.util.Date;
-import java.text.SimpleDateFormat;
-import java.text.ParseException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
 
 class TestAbstractBean {
 

--- a/src/test/java/org/randywebb/wlts/beans/TestAssignment.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestAssignment.java
@@ -1,25 +1,22 @@
 package org.randywebb.wlts.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
 
 class TestAssignment {
 

--- a/src/test/java/org/randywebb/wlts/beans/TestCompanionship.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestCompanionship.java
@@ -1,25 +1,19 @@
 package org.randywebb.wlts.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
 
 class TestCompanionship {
 

--- a/src/test/java/org/randywebb/wlts/beans/TestDetailedMinistered.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestDetailedMinistered.java
@@ -1,28 +1,23 @@
 package org.randywebb.wlts.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.StringWriter;
 import java.util.List;
 import java.util.Scanner;
-import java.io.StringWriter;
-
-import org.randywebb.wlts.reports.DetailedMinisteredCSV;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
+import org.randywebb.wlts.reports.DetailedMinisteredCSV;
 
 class TestDetailedMinistered {
 

--- a/src/test/java/org/randywebb/wlts/beans/TestDistrict.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestDistrict.java
@@ -1,25 +1,20 @@
 package org.randywebb.wlts.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
 
 class TestDistrict {
 

--- a/src/test/java/org/randywebb/wlts/beans/TestHousehold.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestHousehold.java
@@ -1,26 +1,21 @@
 package org.randywebb.wlts.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
 
 class TestHousehold {
 

--- a/src/test/java/org/randywebb/wlts/beans/TestHouseholdMember.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestHouseholdMember.java
@@ -1,23 +1,17 @@
 package org.randywebb.wlts.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
 
 class TestHouseholdMember {
 

--- a/src/test/java/org/randywebb/wlts/beans/TestTeacher.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestTeacher.java
@@ -1,23 +1,17 @@
 package org.randywebb.wlts.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
 
 class TestTeacher {
 

--- a/src/test/java/org/randywebb/wlts/beans/TestVisit.java
+++ b/src/test/java/org/randywebb/wlts/beans/TestVisit.java
@@ -1,23 +1,20 @@
 package org.randywebb.wlts.beans;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvFileSource;
 
 class TestVisit {
 


### PR DESCRIPTION
In eclipse, CTRL+SHIFT+O on project to organize imports across all class files